### PR TITLE
Fix inference

### DIFF
--- a/src/tink/state/Observable.hx
+++ b/src/tink/state/Observable.hx
@@ -24,10 +24,10 @@ abstract Observable<T>(ObservableObject<T>) from ObservableObject<T> to Observab
       return new Measurement(f(p.value, q.value), p.becameInvalid.first(q.becameInvalid));
     });
 
-  public function nextTime(?options:{ ?butNotNow: Bool, ?hires:Bool }, check:T->Bool):Future<T> 
-    return getNext(options, function (v) return if (check(v)) Some(v) else None);
+  public function nextTime(check:T->Bool, ?options:{ ?butNotNow: Bool, ?hires:Bool }):Future<T> 
+    return getNext(function (v) return if (check(v)) Some(v) else None, options);
 
-  public function getNext<R>(?options:{ ?butNotNow: Bool, ?hires:Bool }, select:T->Option<R>):Future<R> {
+  public function getNext<R>(select:T->Option<R>, ?options:{ ?butNotNow: Bool, ?hires:Bool }):Future<R> {
     var ret = Future.trigger(),
         waiting = options != null && options.butNotNow;
 

--- a/tests/TestBasic.hx
+++ b/tests/TestBasic.hx
@@ -105,10 +105,10 @@ class TestBasic {
       Observable.updateAll();
     }
 
-    await(o.nextTime({ hires: true, butNotNow: true }, function (x) return x == 5));
-    await(o.nextTime({ hires: true, }, function (x) return x == 5));
-    await(o.nextTime({ hires: true, butNotNow: true }, function (x) return x == 4));
-    await(o.nextTime({ hires: true, }, function (x) return x == 4));
+    await(o.nextTime(function (x) return x == 5, { hires: true, butNotNow: true }));
+    await(o.nextTime(function (x) return x == 5, { hires: true, }));
+    await(o.nextTime(function (x) return x == 4, { hires: true, butNotNow: true }));
+    await(o.nextTime(function (x) return x == 4, { hires: true, }));
     
     Observable.updateAll();
 


### PR DESCRIPTION
**[BREAKING]**
The compiler couldn't infer the type of the function argument, if the optional `options` is omitted. Fixed by putting optional arguments at the end of the list.

**Without `options`:**
`new State(1).observe().getNext(function(v) return Some($type(v)));`

before: `Unknown<0>`
after: `Int`

**With `options`:**
`new State(1).observe().getNext({}, function(v) return Some($type(v)));`

before: `Int`
after: `Int`

