### PR TITLE
ObservableArray: add missing index increment to iterator()

### DIFF
--- a/src/tink/state/ObservableArray.hx
+++ b/src/tink/state/ObservableArray.hx
@@ -63,7 +63,7 @@ class ObservableArray<T> extends ObservableBase<Change<T>> {
     length;//not pretty
     return {
       hasNext: function () return i < items.length,
-      next: function () return observe(i),
+      next: function () return observe(i++),
     }
   }
 

--- a/tests/TestArrays.hx
+++ b/tests/TestArrays.hx
@@ -3,6 +3,7 @@ package ;
 import tink.state.*;
 
 using tink.CoreApi;
+using Lambda;
 using StringTools;
 
 @:asserts
@@ -63,6 +64,9 @@ class TestArrays {
       counter++;
 
     asserts.assert(counter == a.length);
+
+    var evenCount = a.fold(function (v, count) return count + 1 - v.value % 2, 0);
+    asserts.assert(evenCount == 5);
 
     var keysChanges = 0,
         valuesChanges = 0,


### PR DESCRIPTION
Btw this weirds me out: `var observableValues(default, null):Observable<Iterator<T>>;`
I mean the `Iterator<T>` instead of `T`
Am I the only one?