### PR TITLE
import tink.core modules directly instead of using tink.CoreApi

### DIFF
--- a/src/tink/state/Measurement.hx
+++ b/src/tink/state/Measurement.hx
@@ -1,6 +1,6 @@
 package tink.state;
 
-using tink.CoreApi;
+import tink.core.Pair;
 
 @:deprecated
 abstract Measurement<T>(Pair<T, Future<Noise>>) {

--- a/src/tink/state/Progress.hx
+++ b/src/tink/state/Progress.hx
@@ -1,11 +1,9 @@
 package tink.state;
 
-import tink.state.Observable;
+import tink.core.Pair;
 import tink.core.Progress as Plain;
 import tink.core.Progress.ProgressTrigger as Trigger;
-import tink.core.Callback;
-
-using tink.CoreApi;
+import tink.state.Observable;
 
 @:require(tink_core >= 2)
 @:forward

--- a/src/tink/state/Promised.hx
+++ b/src/tink/state/Promised.hx
@@ -1,7 +1,5 @@
 package tink.state;
 
-using tink.CoreApi;
-
 @:using(tink.state.Promised.PromisedTools)
 enum Promised<T> {
   Loading;

--- a/src/tink/state/import.hx
+++ b/src/tink/state/import.hx
@@ -1,5 +1,12 @@
-import tink.state.internal.Invalidatable;
-import tink.state.internal.*;
+import haxe.ds.Option;
+import tink.core.Callback;
+import tink.core.Error;
+import tink.core.Future;
+import tink.core.Noise;
+import tink.core.Outcome;
+import tink.core.Promise;
+import tink.core.Signal;
+import tink.core.Lazy;
 import tink.state.Promised;
-
-using tink.CoreApi;
+import tink.state.internal.*;
+import tink.state.internal.Invalidatable;


### PR DESCRIPTION
I'm considering introducing tink_state in my codebase, but we have `tink.CoreApi` overshadowed with an empty module for these reasons:
 - we prefer import tink_core modules explicitly
 - we don't have dce=full yet and we don't want to include parts of tink_core that we don't use
 - tink.CoreApi annoyingly shows up in the completion before the actual tink modules (probably the most important thing)

So this PR gets rid of `using tink.CoreApi` across tink_state codebase :) I replaced most of it with direct imports in `imports.hx`, except for `Pair` which is only used in two non-essential places.