### PR TITLE
Is constant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ install:
   - lix download
 
 script:
-  - haxe -lib tink_state tink.state.Observable # this is merely to ensure things compile without -D tink_state.test_subscriptions
   - lix run travix interp
   # - lix run travix neko
   - lix run travix python

--- a/src/tink/state/Observable.hx
+++ b/src/tink/state/Observable.hx
@@ -68,7 +68,7 @@ abstract Observable<T>(ObservableObject<T>) from ObservableObject<T> to Observab
     #end
     if (scheduler == null)
       scheduler = Observable.scheduler;
-    return new Binding(this, callback, scheduler, comparator);
+    return Binding.create(this, callback, scheduler, comparator);
   }
 
   public inline function new(get:Void->T, changed:Signal<Noise>, ?toString #if tink_state.debug , ?pos:haxe.PosInfos #end)

--- a/src/tink/state/Observable.hx
+++ b/src/tink/state/Observable.hx
@@ -258,6 +258,9 @@ private class ConstObservable<T> implements ObservableObject<T> {
   public function getRevision()
     return revision;
 
+  public function canFire()
+    return true;
+
   public function new(value, ?toString:()->String #if tink_state.debug , ?pos:haxe.PosInfos #end) {
     this.value = value;
     #if tink_state.debug

--- a/src/tink/state/Observable.hx
+++ b/src/tink/state/Observable.hx
@@ -208,11 +208,6 @@ abstract Observable<T>(ObservableObject<T>) from ObservableObject<T> to Observab
   static inline function neq<T>(a:Observable<T>, b:Observable<T>):Bool
     return !eq(a, b);
 
-  #if tink_state.test_subscriptions
-    static function subscriptionCount()
-      return @:privateAccess AutoObservable.subscriptionCount;
-  #end
-
   #if tink_state.debug
     public function dependencyTree():DependencyTree
       return new DependencyTree(cast this);

--- a/src/tink/state/ObservableArray.hx
+++ b/src/tink/state/ObservableArray.hx
@@ -248,6 +248,9 @@ private class DerivedView<T> implements ArrayView<T> {
   public function getRevision()
     return self().getRevision();
 
+  public function canFire()
+    return self().canFire();
+
   public function new(o)
     this.o = o;
 

--- a/src/tink/state/ObservableDate.hx
+++ b/src/tink/state/ObservableDate.hx
@@ -13,6 +13,9 @@ class ObservableDate implements ObservableObject<Bool> {
     inline function get_passed():Bool
       return _observable.getValue();
 
+  public function canFire()
+    return passed;
+
   public function getRevision()
     return _observable.getRevision();
 

--- a/src/tink/state/ObservableMap.hx
+++ b/src/tink/state/ObservableMap.hx
@@ -59,6 +59,9 @@ private class Derived<K, V> implements MapView<K, V> {
   public function new(o)
     this.o = o;
 
+  public function canFire()
+    return self().canFire();
+
   public function getRevision()
     return self().getRevision();
 

--- a/src/tink/state/State.hx
+++ b/src/tink/state/State.hx
@@ -55,6 +55,9 @@ private class CompoundState<T> implements StateObject<T> {
     this.comparator = comparator;
   }
 
+  public function canFire()
+    return data.canFire();
+
   public function getRevision()
     return data.getRevision();
 

--- a/src/tink/state/internal/AutoObservable.hx
+++ b/src/tink/state/internal/AutoObservable.hx
@@ -77,10 +77,6 @@ private class SubscriptionTo<T> {
 
   public var used = true;
 
-  #if tink_state.test_subscriptions
-    var connected:Bool = false;
-  #end
-
   public function new<X>(source, cur, owner:AutoObservable<X>) {
     this.source = source;
     this.last = cur;
@@ -108,13 +104,6 @@ private class SubscriptionTo<T> {
   }
 
   public inline function disconnect():Void {
-    #if tink_state.test_subscriptions // TODO: this probably should be removed, and tested indirectly via State.onStatusChange
-      if (connected) {
-        @:privateAccess AutoObservable.subscriptionCount--;
-        connected = false;
-      }
-      else throw 'what?';
-    #end
     #if tink_state.debug
       logger.disconnected(source, cast owner);
     #end
@@ -122,13 +111,6 @@ private class SubscriptionTo<T> {
   }
 
   public inline function connect():Void {
-    #if tink_state.test_subscriptions
-      if (connected) throw 'what?';
-      else {
-        connected = true;
-        @:privateAccess AutoObservable.subscriptionCount++;
-      }
-    #end
     #if tink_state.debug
       logger.connected(source, cast owner);
     #end
@@ -148,9 +130,6 @@ private enum abstract AutoObservableStatus(Int) {
 class AutoObservable<T> extends Invalidator
   implements Invalidatable implements Derived implements ObservableObject<T> {
 
-  #if tink_state.test_subscriptions
-    static var subscriptionCount = 0;
-  #end
   static var cur:Derived;
 
   var compute:Computation<T>;

--- a/src/tink/state/internal/AutoObservable.hx
+++ b/src/tink/state/internal/AutoObservable.hx
@@ -236,7 +236,7 @@ class AutoObservable<T> extends Invalidator
 
   static public inline function track<V>(o:ObservableObject<V>):V {
     var ret = o.getValue();
-    if (cur != null)
+    if (cur != null && !o.canFire())
       cur.subscribeTo(o, ret);
     return ret;
   }
@@ -254,6 +254,7 @@ class AutoObservable<T> extends Invalidator
       #if tink_state.debug
       logger.revalidated(this, false);
       #end
+      if (subscriptions.length == 0) dispose();
     }
 
     var prevSubs = subscriptions,

--- a/src/tink/state/internal/AutoObservable.hx
+++ b/src/tink/state/internal/AutoObservable.hx
@@ -94,7 +94,7 @@ private class SubscriptionTo<T> {
     if (nextRev == lastRev) return false;
     lastRev = nextRev;
     var before = last;
-    last = Observable.untracked(source.getValue);// not sure this has to be untracked
+    last = source.getValue();
     return !source.getComparator().eq(last, before);
   }
 

--- a/src/tink/state/internal/AutoObservable.hx
+++ b/src/tink/state/internal/AutoObservable.hx
@@ -236,7 +236,7 @@ class AutoObservable<T> extends Invalidator
 
   static public inline function track<V>(o:ObservableObject<V>):V {
     var ret = o.getValue();
-    if (cur != null && !o.canFire())
+    if (cur != null && o.canFire())
       cur.subscribeTo(o, ret);
     return ret;
   }
@@ -254,6 +254,7 @@ class AutoObservable<T> extends Invalidator
       #if tink_state.debug
       logger.revalidated(this, false);
       #end
+      trace(subscriptions.length);
       if (subscriptions.length == 0) dispose();
     }
 

--- a/src/tink/state/internal/AutoObservable.hx
+++ b/src/tink/state/internal/AutoObservable.hx
@@ -254,7 +254,6 @@ class AutoObservable<T> extends Invalidator
       #if tink_state.debug
       logger.revalidated(this, false);
       #end
-      trace(subscriptions.length);
       if (subscriptions.length == 0) dispose();
     }
 

--- a/src/tink/state/internal/ObjectMap.hx
+++ b/src/tink/state/internal/ObjectMap.hx
@@ -1,6 +1,6 @@
 package tink.state.internal;
 
-@:forward(keys, exists)
+@:forward(keys, exists, clear)
 abstract ObjectMap<K:{}, V>(haxe.ds.ObjectMap<K, V>) {
   public inline function new()
     this = new haxe.ds.ObjectMap<K, V>();

--- a/src/tink/state/internal/ObjectMap.js.hx
+++ b/src/tink/state/internal/ObjectMap.js.hx
@@ -2,6 +2,7 @@ package tink.state.internal;
 
 import js.lib.*;
 
+@:forward(clear)
 abstract ObjectMap<K:{}, V>(Map<K, V>) {
   public inline function new()
     this = new Map<K, V>();

--- a/src/tink/state/internal/ObservableObject.hx
+++ b/src/tink/state/internal/ObservableObject.hx
@@ -6,6 +6,7 @@ interface ObservableObject<T> {
   function isValid():Bool;
   function getComparator():Comparator<T>;
   function onInvalidate(i:Invalidatable):CallbackLink;
+  function canFire():Bool;
   #if tink_state.debug
   function getObservers():Iterator<Invalidatable>;
   function getDependencies():Iterator<Observable<Any>>;

--- a/src/tink/state/internal/SignalObservable.hx
+++ b/src/tink/state/internal/SignalObservable.hx
@@ -14,7 +14,7 @@ class SignalObservable<X, T> implements ObservableObject<T> {
   final changed:Signal<Noise>;
 
   public function canFire()
-    return #if (tink_core >= "2") changed.disposed #else true #end;
+    return #if (tink_core >= "2") !changed.disposed #else true #end;
 
   public function new(get, changed:Signal<Noise>, ?toString:(id:Int)->String #if tink_state.debug , ?pos:haxe.PosInfos #end) {
     this.get = get;

--- a/src/tink/state/internal/SignalObservable.hx
+++ b/src/tink/state/internal/SignalObservable.hx
@@ -13,6 +13,9 @@ class SignalObservable<X, T> implements ObservableObject<T> {
   final observers = new Map();
   final changed:Signal<Noise>;
 
+  public function canFire()
+    return #if (tink_core >= "2") changed.disposed #else true #end;
+
   public function new(get, changed:Signal<Noise>, ?toString:(id:Int)->String #if tink_state.debug , ?pos:haxe.PosInfos #end) {
     this.get = get;
     this.changed = changed;

--- a/tests.hxml
+++ b/tests.hxml
@@ -1,4 +1,5 @@
 -cp tests
+-D no-deprecation-warnings
 -D tink_state.test_subscriptions
 -lib tink_unittest
 -main RunTests

--- a/tests.hxml
+++ b/tests.hxml
@@ -1,6 +1,5 @@
 -cp tests
 -D no-deprecation-warnings
--D tink_state.test_subscriptions
 -lib tink_unittest
 -main RunTests
 

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -4,15 +4,16 @@ class RunTests {
 
   static function main() {
     tink.testrunner.Runner.run(tink.unit.TestBatch.make([
-      new TestBasic(),
-      new TestDate(),
-      new TestAuto(),
-      new TestAutorun(),
-      new TestMaps(),
-      new TestArrays(),
-      new TestScheduler(),
-      new TestProgress(),
-      new issues.Issue51(),
+      // new TestBasic(),
+      // new TestDate(),
+      // new TestAuto(),
+      // new TestAutorun(),
+      // new TestMaps(),
+      // new TestArrays(),
+      // new TestScheduler(),
+      // new TestProgress(),
+      // new issues.Issue51(),
+      new issues.Issue61(),
     ]))
       .handle(function(result) {
         travix.Logger.exit(result.summary().failures.length);

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -4,15 +4,15 @@ class RunTests {
 
   static function main() {
     tink.testrunner.Runner.run(tink.unit.TestBatch.make([
-      // new TestBasic(),
-      // new TestDate(),
-      // new TestAuto(),
-      // new TestAutorun(),
-      // new TestMaps(),
-      // new TestArrays(),
-      // new TestScheduler(),
-      // new TestProgress(),
-      // new issues.Issue51(),
+      new TestBasic(),
+      new TestDate(),
+      new TestAuto(),
+      new TestAutorun(),
+      new TestMaps(),
+      new TestArrays(),
+      new TestScheduler(),
+      new TestProgress(),
+      new issues.Issue51(),
       new issues.Issue61(),
     ]))
       .handle(function(result) {

--- a/tests/TestAuto.hx
+++ b/tests/TestAuto.hx
@@ -209,12 +209,6 @@ class TestAuto {
   }
 
   public function testSubs() {
-    #if tink_state.test_subscriptions
-    function count()
-      return @:privateAccess Observable.subscriptionCount();
-
-    var initial = count();//it's possible other tests leave behind subscriptions ... should probably warn in that case
-    #end
 
     var liveCount = 0;
     function watch(alive:Bool)
@@ -236,12 +230,9 @@ class TestAuto {
     var result = 0;
     var watch = Observable.auto(add).bind(x -> result = x, direct);
 
-    function check(?pos:haxe.PosInfos) {
-      #if tink_state.test_subscriptions
-      asserts.assert(selectedCount.value + 1 + initial == count());
-      #end
+    function check(?pos:haxe.PosInfos)
       asserts.assert(liveCount == selectedCount.value);
-    }
+
     asserts.assert(result == 18);
     check();
 

--- a/tests/issues/Issue61.hx
+++ b/tests/issues/Issue61.hx
@@ -1,0 +1,34 @@
+package issues;
+
+import tink.state.Scheduler;
+import tink.state.internal.ObservableObject;
+import tink.state.State;
+import tink.state.Observable;
+
+
+@:asserts
+class Issue61 {
+  public function new() {}
+
+  public function test() {
+    var first = true,
+        s = new State(7);
+
+    var o = Observable.auto(() -> if (first) {
+      first = false;
+      s.value;
+    } else 42);
+
+    function canFire()
+      return (o:ObservableObject<Int>).canFire();
+
+    var log = [];
+    o.bind(v -> log.push(v), Scheduler.direct);
+    asserts.assert(canFire());
+    asserts.assert(canFire());
+    s.set(123);
+    asserts.assert(!canFire());
+    asserts.assert(log.join(',') == '7,42');
+    return asserts.done();
+  }
+}

--- a/tests/issues/Issue61.hx
+++ b/tests/issues/Issue61.hx
@@ -19,6 +19,8 @@ class Issue61 {
       s.value;
     } else 42);
 
+    var o = Observable.auto(() -> o.value);
+
     function canFire()
       return (o:ObservableObject<Int>).canFire();
 


### PR DESCRIPTION
This solves #61, although I finally decided to call it `canFire` rather than `isConstant`, because even though more technical, it is more precise.

This makes auto observables that depend on nothing (that could in turn fire) cheaper:

1. accessing these from other auto observables skips tracking
2. creating a binding on them (and constant observables) comes at no cost
3. when an auto-observable recomputes in a way that is without dependencies that can fire themselves, all bindings clean themselves up after firing.

Beyond that, it *should* have no noticeable effect. But like all "clever" things it comes with the risk of subtly breaking something. If any of you could find the time to confirm it behaves well in your projects, that'd be great.

From my end, I found no issues and memory use reduction of ~10% in a larger project (which doesn't use that many constant observables, but hey, at least there was a measurable difference).