### PR TITLE
Cleanup deprecations

### DIFF
--- a/src/tink/state/Observable.hx
+++ b/src/tink/state/Observable.hx
@@ -145,7 +145,7 @@ abstract Observable<T>(ObservableObject<T>) from ObservableObject<T> to Observab
 
   static public var isUpdating(default, null):Bool = false;
 
-  @:extern static inline function performUpdate<T>(fn:Void->T) {
+  #if (haxe_ver < 4) @:extern #else extern #end static inline function performUpdate<T>(fn:Void->T) {
     var wasUpdating = isUpdating;
     isUpdating = true;
     return Error.tryFinally(fn, () -> isUpdating = wasUpdating);

--- a/src/tink/state/ObservableArray.hx
+++ b/src/tink/state/ObservableArray.hx
@@ -222,7 +222,7 @@ private class ArrayImpl<T> extends Invalidator implements ArrayView<T> {
   public function copy()
     return calc(() -> entries.copy());
 
-  @:extern inline function update<T>(fn:Void->T) {
+  #if (haxe_ver < 4) @:extern #else extern #end inline function update<T>(fn:Void->T) {
     var ret = fn();
     if (valid) {
       valid = false;
@@ -231,7 +231,7 @@ private class ArrayImpl<T> extends Invalidator implements ArrayView<T> {
     return ret;
   }
 
-  @:extern inline function calc<T>(f:Void->T) {
+  #if (haxe_ver < 4) @:extern #else extern #end inline function calc<T>(f:Void->T) {
     valid = true;
     AutoObservable.track(this);
     return f();

--- a/src/tink/state/ObservableMap.hx
+++ b/src/tink/state/ObservableMap.hx
@@ -171,7 +171,7 @@ private class MapImpl<K, V> extends Invalidator implements MapView<K, V> impleme
   public function getComparator()
     return neverEqual;
 
-  @:extern inline function update<T>(fn:Void->T) {
+  #if (haxe_ver < 4) @:extern #else extern #end inline function update<T>(fn:Void->T) {
     var ret = fn();
     if (valid) {
       valid = false;
@@ -180,7 +180,7 @@ private class MapImpl<K, V> extends Invalidator implements MapView<K, V> impleme
     return ret;
   }
 
-  @:extern inline function calc<T>(f:Void->T) {
+  #if (haxe_ver < 4) @:extern #else extern #end inline function calc<T>(f:Void->T) {
     valid = true;
     AutoObservable.track(this);
     return f();

--- a/src/tink/state/Promised.hx
+++ b/src/tink/state/Promised.hx
@@ -13,7 +13,7 @@ enum PromisedWith<T, E> {
 class PromisedTools {
   static public function next<A, B>(a:Promised<A>, f:Next<A, B>):Promise<B>
     return switch a {
-      case Loading: Promise.NEVER #if (tink_core < "2" && haxe_ver >= "4.2") .next(_ -> (null:B)) #end;
+      case Loading: Promise.never() #if (tink_core < "2" && haxe_ver >= "4.2") .next(_ -> (null:B)) #end;
       case Failed(e): e;
       case Done(a): f(a);
     }

--- a/src/tink/state/State.hx
+++ b/src/tink/state/State.hx
@@ -105,7 +105,7 @@ private class GuardedState<T> extends SimpleState<T> {
       if (!guardApplied) applyGuard();
       else value;
 
-  @:extern inline function applyGuard():T {
+    #if (haxe_ver < 4) @:extern #else extern #end inline function applyGuard():T {
     this.guardApplied = true;
     return value = guard(value);
   }


### PR DESCRIPTION
Been using this library in a Haxe 4 project and thought I'd clean up my warning list a bit. I think the conditionals should cover Haxe 3 and earlier but I haven't tested those.